### PR TITLE
fix: treat false and zero as JSON bodies

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,9 +6,10 @@
 
 module.exports = function isJSON (body) {
   return !(
-    !body ||
+    body === undefined ||
+    body === null ||
     typeof body === 'string' ||
-    typeof body.pipe === 'function' ||
+    (body && typeof body.pipe === 'function') ||
     Buffer.isBuffer(body)
   )
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,7 +5,7 @@ const isJSON = require('..')
 describe('koa-is-json test', () => {
   let body
 
-  it('Condition 1: !body', () => {
+  it('Condition 1: undefined body', () => {
     assert.ok(!isJSON())
   })
 
@@ -33,7 +33,15 @@ describe('koa-is-json test', () => {
     assert.ok(!isJSON(null))
   })
 
-  it('Condition 6: check correct body', () => {
+  it('Condition 6: check false boolean', () => {
+    assert.ok(isJSON(false))
+  })
+
+  it('Condition 7: check zero number', () => {
+    assert.ok(isJSON(0))
+  })
+
+  it('Condition 8: check correct body', () => {
     body = JSON.parse(JSON.stringify({ msg: 'hello world !' }))
     assert.ok(isJSON(body))
   })


### PR DESCRIPTION
Closes #1.

This keeps the existing non-JSON handling for `undefined`, `null`, strings, streams, and buffers, but stops treating `false` and `0` as absent bodies. That makes falsy booleans and numbers consistent with the existing behavior for `true` and non-zero numbers.

Verification:
- `npm run test-only`
- `npm run lint`
- `npm test`
- `git diff --check`

## Summary by Sourcery

Update JSON body detection to treat falsy boolean and numeric values as valid JSON bodies while preserving special handling for undefined, null, strings, streams, and buffers.

Bug Fixes:
- Ensure false and 0 are treated as valid JSON bodies instead of being considered absent.

Tests:
- Add and adjust unit tests to cover undefined, false, and 0 bodies and validate updated JSON detection behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSON detection logic to properly handle boolean and numeric falsy values.
  
* **Tests**
  * Expanded test coverage for edge cases with updated test descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->